### PR TITLE
Removing buttons outline

### DIFF
--- a/colorGame.css
+++ b/colorGame.css
@@ -65,6 +65,7 @@ button {
 	transition: all 0.3s;
 	-webkit-transition: all 0.3s;
 	-moz-transition: all 0.3s;
+	outline: none; /*to get rid of the blue outline when clicked*/
 }
 
 button:hover {


### PR DESCRIPTION
This commit removes the blue outline on every button made by the browser after clicking on each button.
The aesthetic of said buttons were frowned upon.