### PR TITLE
Fix Reset Messaging

### DIFF
--- a/colorGame.js
+++ b/colorGame.js
@@ -58,6 +58,8 @@ $resetButton.addEventListener("click", function() {
 	}
 	//reset background color for h1
 	$h1.style.backgroundColor = H1_BG_COLOR;
+	$messageDisplay.textContent = "";
+	this.textContent = "New Colors";
 });
 
 for (var i = 0; i < $squares.length; i++) {


### PR DESCRIPTION
When the player finds the correct colour (he/she won the game), a 'Correct!' message is displayed and the reset button text changes to 'Play Again?'. 
After clicking on the button to play again, said messages weren't changing at all, leading the player to be confused about the game state.
This commit is fixing that by hiding the 'Correct!' message and changing the reset button text to 'New Colours'.